### PR TITLE
vcpkg support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ string(CONCAT DESCRIPTION_STRING "The AWSLabs Enhanced libraries for C++ tight i
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 find_package(Git QUIET) # Adding development helper tools as git_hash built when available.
-find_package(tl-expected)
 include(project_version)
 obtain_project_version(AWSLABS_ENHANCED_CPP_PROJECT_VERSION awslabs-enhanced-cpp_GIT_HASH)
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,16 @@
+{
+  "name" : "high-level-enhancements-for-aws-in-cpp",
+  "version-string" : "1.0.0",
+  "builtin-baseline" : "65e91ebd9e1d8a5c054b98b87abef68d5d36ce6f",
+  "dependencies" : [ {
+    "name" : "aws-sdk-cpp",
+    "version>=" : "1.11.65",
+    "features": ["s3","lambda"]
+  }, {
+    "name" : "gtest",
+    "version>=" : "1.13.0"
+  }, {
+    "name" : "tl-expected",
+    "version>=" : "1.1.0"
+  } ]
+}


### PR DESCRIPTION
- Removing duplicated find_package call in cmake
- Adding vcpkg.json to pull available dependencies

*Issue #, if available:*

*Description of changes:*
This change enable users that manage dependencies using vcpkg by command line or IDE integration to pull most of the dependencies automatically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
